### PR TITLE
Unicode runes & Random numbers

### DIFF
--- a/haikunator.go
+++ b/haikunator.go
@@ -65,12 +65,22 @@ func (h *Haikunator) Haikunate() string {
 		h.TokenChars = "0123456789abcdef"
 	}
 
-	adjective := h.Adjectives[h.Random.Intn(len(h.Adjectives))]
-	noun := h.Nouns[h.Random.Intn(len(h.Nouns))]
+	var adjective, noun string
+
+	if len(h.Adjectives) > 0 { // Random.Intn panics otherwise
+		adjective = h.Adjectives[h.Random.Intn(len(h.Adjectives))]
+	}
+
+	if len(h.Nouns) > 0 {
+		noun = h.Nouns[h.Random.Intn(len(h.Nouns))]
+	}
+
 	var buffer bytes.Buffer
 
-	for i := 0; i < h.TokenLength; i++ {
-		buffer.WriteByte(h.TokenChars[h.Random.Intn(len(h.TokenChars))])
+	if len(h.TokenChars) > 0 {
+		for i := 0; i < h.TokenLength; i++ {
+			buffer.WriteByte(h.TokenChars[h.Random.Intn(len(h.TokenChars))])
+		}
 	}
 
 	token := buffer.String()

--- a/haikunator.go
+++ b/haikunator.go
@@ -75,15 +75,16 @@ func (h *Haikunator) Haikunate() string {
 		noun = h.Nouns[h.Random.Intn(len(h.Nouns))]
 	}
 
-	var buffer bytes.Buffer
+	var token string
 
 	if len(h.TokenChars) > 0 {
+		var buffer bytes.Buffer
 		for i := 0; i < h.TokenLength; i++ {
 			buffer.WriteByte(h.TokenChars[h.Random.Intn(len(h.TokenChars))])
 		}
+		token = buffer.String()
 	}
 
-	token := buffer.String()
 	sections := deleteEmpty([]string{adjective, noun, token})
 	return strings.Join(sections, h.Delimiter)
 }

--- a/haikunator.go
+++ b/haikunator.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // A Haikunator represents all options needed to use haikunate()
@@ -80,7 +81,8 @@ func (h *Haikunator) Haikunate() string {
 	if len(h.TokenChars) > 0 {
 		var buffer bytes.Buffer
 		for i := 0; i < h.TokenLength; i++ {
-			buffer.WriteByte(h.TokenChars[h.Random.Intn(len(h.TokenChars))])
+			randomIndex := h.Random.Intn(utf8.RuneCountInString(h.TokenChars))
+			buffer.WriteRune([]rune(h.TokenChars)[randomIndex])
 		}
 		token = buffer.String()
 	}

--- a/haikunator_test.go
+++ b/haikunator_test.go
@@ -197,3 +197,12 @@ func TestCustomRandom(t *testing.T) {
 		t.Error(haiku1, "does not match with ", haiku2)
 	}
 }
+
+func TestZeroLengthOptionsPanic(t *testing.T) {
+	haikunator := NewHaikunator()
+	haikunator.Adjectives = make([]string, 0)
+	haikunator.Nouns = make([]string, 0)
+	haikunator.TokenChars = ""
+
+	haikunator.Haikunate() // should not panic when generating random numbers
+}


### PR DESCRIPTION
Two small improvements:
#### Support for unicode runes

Running this code would produce

``` go
h := haikunator.NewHaikunator()
h.TokenChars = "忠犬ハチ公"
fmt.Println(h.Haikunate())
```

_Previously_

![screen shot 2015-12-24 at 1 44 28 am](https://cloud.githubusercontent.com/assets/6028224/11991423/f6e34cf4-a9df-11e5-84cd-216dc3650d5a.png)

_Now:_

![screen shot 2015-12-24 at 1 44 44 am](https://cloud.githubusercontent.com/assets/6028224/11991421/f3560cc0-a9df-11e5-9a69-e1b02191529f.png)
#### Potential panic when generating random numbers

`Random.Intn` panics if the argument <= 0. This can happen if the user defined adjectives, nouns, or token chars is empty.
